### PR TITLE
W1: category 전체 조회 API

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -4,10 +4,11 @@ import { AppService } from './app.service';
 import { configModule } from './modules/config.module';
 import { LoggerMiddleware } from '../common/middlewares/logger.middleware';
 import { RegionModule } from '../region/region.module';
+import { CategoryModule } from 'src/category/category.module';
 import { CommonModule } from '../common/common.module';
 
 @Module({
-  imports: [configModule, RegionModule, CommonModule],
+  imports: [configModule, RegionModule, CategoryModule, CommonModule],
   controllers: [AppController],
   providers: [AppService],
 })

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -1,9 +1,17 @@
-import { Controller } from '@nestjs/common';
-import { ApiTags } from '@nestjs/swagger';
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiOkResponse } from '@nestjs/swagger';
 import { CategoryService } from './category.service';
+import { CategoryListDto } from './dto/category.dto';
 
 @Controller('categories')
 @ApiTags('Category API')
 export class CategoryController {
   constructor(private readonly categoryService: CategoryService) {}
+
+  @Get()
+  @ApiOperation({ summary: '모든 카테고리 리스트' })
+  @ApiOkResponse({ type: CategoryListDto })
+  async findAllCategories(): Promise<CategoryListDto> {
+    return this.categoryService.findAllCategories();
+  }
 }

--- a/src/category/category.controller.ts
+++ b/src/category/category.controller.ts
@@ -1,0 +1,9 @@
+import { Controller } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
+import { CategoryService } from './category.service';
+
+@Controller('categories')
+@ApiTags('Category API')
+export class CategoryController {
+  constructor(private readonly categoryService: CategoryService) {}
+}

--- a/src/category/category.module.ts
+++ b/src/category/category.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { CategoryController } from './category.controller';
+import { CategoryService } from './category.service';
+import { CategoryRepository } from './category.repository';
+
+@Module({
+  controllers: [CategoryController],
+  providers: [CategoryService, CategoryRepository],
+})
+export class CategoryModule {}

--- a/src/category/category.repository.ts
+++ b/src/category/category.repository.ts
@@ -1,7 +1,17 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from 'src/common/services/prisma.service';
+import { CategoryData } from './type/category-data.type';
 
 @Injectable()
 export class CategoryRepository {
   constructor(private readonly prisma: PrismaService) {}
+
+  async findAllCategories(): Promise<CategoryData[]> {
+    return this.prisma.category.findMany({
+      select: {
+        id: true,
+        name: true,
+      },
+    });
+  }
 }

--- a/src/category/category.repository.ts
+++ b/src/category/category.repository.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { PrismaService } from 'src/common/services/prisma.service';
+
+@Injectable()
+export class CategoryRepository {
+  constructor(private readonly prisma: PrismaService) {}
+}

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common';
+import { CategoryRepository } from './category.repository';
+
+@Injectable()
+export class CategoryService {
+  constructor(private readonly categoryRepository: CategoryRepository) {}
+}

--- a/src/category/category.service.ts
+++ b/src/category/category.service.ts
@@ -1,7 +1,16 @@
 import { Injectable } from '@nestjs/common';
 import { CategoryRepository } from './category.repository';
+import { CategoryListDto } from './dto/category.dto';
+import { CategoryData } from './type/category-data.type';
 
 @Injectable()
 export class CategoryService {
   constructor(private readonly categoryRepository: CategoryRepository) {}
+
+  async findAllCategories(): Promise<CategoryListDto> {
+    const categories: CategoryData[] =
+      await this.categoryRepository.findAllCategories();
+
+    return CategoryListDto.from(categories);
+  }
 }

--- a/src/category/dto/category.dto.ts
+++ b/src/category/dto/category.dto.ts
@@ -1,0 +1,41 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { CategoryData } from '../type/category-data.type';
+
+export class CategoryDto {
+  @ApiProperty({
+    description: '카테고리 ID',
+    type: Number,
+  })
+  id!: number;
+
+  @ApiProperty({
+    description: '카테고리 이름',
+    type: String,
+  })
+  name!: string;
+
+  static from(category: CategoryData): CategoryDto {
+    return {
+      id: category.id,
+      name: category.name,
+    };
+  }
+
+  static fromArray(categories: CategoryData[]): CategoryDto[] {
+    return categories.map((category) => this.from(category));
+  }
+}
+
+export class CategoryListDto {
+  @ApiProperty({
+    description: '카테고리 목록',
+    type: [CategoryDto],
+  })
+  categories!: CategoryDto[];
+
+  static from(categories: CategoryData[]): CategoryListDto {
+    return {
+      categories: CategoryDto.fromArray(categories),
+    };
+  }
+}

--- a/src/category/type/category-data.type.ts
+++ b/src/category/type/category-data.type.ts
@@ -1,0 +1,4 @@
+export type CategoryData = {
+  id: number;
+  name: string;
+};


### PR DESCRIPTION
## Type
PR 종류를 확인해 주세요.
- [ ] Refactor
- [x] New feature
- [ ] Bug fix
- [ ] CI/CD, INFRA
- [ ] Etc

## Purpose
- Category 모듈 추가 및 Category를 전체 조회하는 `GET /categories` 메소드 구현


## Additional context
- 다음부턴 제때제때 하겠습니다...
- 왜 DTO 배열이 아닌 ListDTO 를 별도로 만드는지 궁금했는데요, 슬라이드에 이미 답이 나와있었네요. 하위호환성을 유지하기 위함이었군요

## Checklist
- Fork 해서 push 하는건 처음해보는데 제대로 했겠죠..?